### PR TITLE
feat(cli): implement pluginspp remove command flow

### DIFF
--- a/apps/pluginspp-cli/src/commands/add.ts
+++ b/apps/pluginspp-cli/src/commands/add.ts
@@ -762,7 +762,7 @@ function configureAddCommand(
     .description("Install plugins from local path or git source")
     .argument("<source>", "Plugin source path or URL")
     .option("-a, --agent <agents...>", "Target agent(s) for installation")
-    .option("-s, --plugin <plugins...>", "Install only selected plugin(s)")
+    .option("-p, --plugin <plugins...>", "Install only selected plugin(s)")
     .option("-l, --list", "List plugins from source without installing")
     .option("--symlink", "Install by symlinking files to all agents")
     .option(

--- a/apps/pluginspp-cli/src/commands/remove.ts
+++ b/apps/pluginspp-cli/src/commands/remove.ts
@@ -1,17 +1,579 @@
-import { type Command } from "commander";
-import { type CliCommandContext } from "../command-builder";
+import fs from "node:fs";
+import path from "node:path";
+import { Command } from "commander";
+import type {
+  AgentType,
+  RemoveOptions,
+} from "@skillspp/core/contracts/runtime-types";
+import {
+  AGENTS,
+  getAgentPluginsDir,
+  normalizeAgentSelectionInput,
+  resolveAddPluginAgentSelectionRows,
+  resolveAgents,
+  type SelectionRow,
+} from "@skillspp/core/agents";
+import { canUseInteractive } from "../interactive";
+import {
+  parseStandaloneCommand,
+  type CliCommandContext,
+} from "../command-builder";
+import {
+  completedStepsSection,
+  failedStepsSection,
+  linesSection,
+  manySelectionClosedSection,
+  removeCompletionSummarySection,
+  renderStaticScreen,
+  singleSelectionClosedSection,
+  sourceSection,
+  uninstallSummarySection,
+} from "../ui/screens";
+import {
+  type ManySelectionViewConfig,
+  type SelectionKeyHint,
+  runManySelectionStep,
+  runOneSelectionStep,
+  type SingleSelectionViewConfig,
+} from "../ui/selection-step";
+import { shortenHomePath } from "../ui/format";
+
+type RemoveCommanderOptions = {
+  agent?: string[];
+  plugin?: string[];
+  global?: boolean;
+  nonInteractive?: boolean;
+};
+
+function toRemoveOptions(options: RemoveCommanderOptions): RemoveOptions {
+  return {
+    global: Boolean(options.global),
+    agent: normalizeAgentSelectionInput(options.agent),
+    agentFlagProvided: Boolean(options.agent && options.agent.length > 0),
+    skill: options.plugin,
+    nonInteractive: Boolean(options.nonInteractive),
+  };
+}
+
+const PLUGIN_NAME_WIDTH = 38;
+const PLUGIN_DESC_WIDTH = 1;
+const AGENT_NAME_WIDTH = 26;
+const AGENT_DESC_WIDTH = 40;
+
+const REMOVE_PLUGINS_KEY_HINTS: SelectionKeyHint[] = [
+  { key: "", action: "type to search" },
+  { key: "space", action: "toggle" },
+  { key: "ctrl+a", action: "all" },
+  { key: "ctrl+l", action: "invert" },
+  { key: "enter", action: "confirm" },
+];
+
+const REMOVE_AGENTS_KEY_HINTS: SelectionKeyHint[] = [
+  { key: "", action: "type to search" },
+  { key: "space", action: "toggle" },
+  { key: "ctrl+a", action: "all" },
+  { key: "ctrl+l", action: "invert" },
+  { key: "enter", action: "confirm" },
+];
+
+const REMOVE_CONFIRM_KEY_HINTS: SelectionKeyHint[] = [
+  { key: "↑↓", action: "navigate" },
+  { key: "enter", action: "confirm" },
+];
+
+const REMOVE_PLUGINS_SELECTION_VIEW: ManySelectionViewConfig = {
+  title: "Choose Plugins",
+  countLine: "installed",
+  instructionLine: "Select plugins to uninstall (space to toggle)",
+  labelWidth: PLUGIN_NAME_WIDTH,
+  descWidth: PLUGIN_DESC_WIDTH,
+  minWidth: 74,
+  defaultHints: REMOVE_PLUGINS_KEY_HINTS,
+};
+
+const REMOVE_AGENTS_SELECTION_VIEW: ManySelectionViewConfig = {
+  title: "Choose Agents",
+  countLine: "detected for selected plugins",
+  instructionLine: "Select agents to remove from (space to toggle)",
+  labelWidth: AGENT_NAME_WIDTH,
+  descWidth: AGENT_DESC_WIDTH,
+  minWidth: 74,
+  defaultHints: REMOVE_AGENTS_KEY_HINTS,
+};
+
+const REMOVE_CONFIRM_SELECTION_VIEW: SingleSelectionViewConfig = {
+  title: "Confirm Uninstall",
+  instructionLine: "Confirm uninstall operation",
+  minWidth: 74,
+};
+
+async function renderRemoveFlowHeader(): Promise<void> {}
+
+function buildRemovePluginSelectionRows(pluginNames: string[]): SelectionRow[] {
+  return pluginNames.map((name) => ({
+    id: name,
+    label: name,
+  }));
+}
+
+function buildRemoveAgentSelectionRows(
+  agents: AgentType[],
+  scopedAgentRowsById: Map<AgentType, SelectionRow>,
+): SelectionRow[] {
+  return agents.map((agent) => ({
+    id: agent,
+    label: scopedAgentRowsById.get(agent)?.label ?? AGENTS[agent].displayName,
+    description: scopedAgentRowsById.get(agent)?.description,
+  }));
+}
+
+function buildRemoveConfirmSelectionRows(): SelectionRow[] {
+  return [
+    { id: "yes", label: "Yes" },
+    { id: "no", label: "No" },
+  ];
+}
+
+function renderRemovePluginsPanel(options: {
+  plugins: string[];
+  selectedNames: string[];
+}) {
+  return manySelectionClosedSection(
+    REMOVE_PLUGINS_SELECTION_VIEW,
+    buildRemovePluginSelectionRows(options.plugins),
+    options.selectedNames,
+  );
+}
+
+function renderRemoveAgentsPanel(options: {
+  agents: AgentType[];
+  selectedAgents: AgentType[];
+  scopedAgentRowsById: Map<AgentType, SelectionRow>;
+}) {
+  return manySelectionClosedSection(
+    REMOVE_AGENTS_SELECTION_VIEW,
+    buildRemoveAgentSelectionRows(options.agents, options.scopedAgentRowsById),
+    options.selectedAgents,
+  );
+}
+
+function renderRemoveConfirmPanel(options: { selectedId: string }) {
+  return singleSelectionClosedSection(
+    REMOVE_CONFIRM_SELECTION_VIEW,
+    options.selectedId === "no" ? "No" : "Yes",
+  );
+}
+
+function renderRemoveUninstallSummaryBox(options: {
+  globalInstall: boolean;
+  pluginNames: string[];
+  agentDisplayNames: string[];
+}) {
+  return uninstallSummarySection({
+    globalInstall: options.globalInstall,
+    itemNames: options.pluginNames,
+    itemLabel: "Plugins",
+    agentDisplayNames: options.agentDisplayNames,
+  });
+}
+
+type InstallIndex = {
+  agentsByPlugin: Map<string, Set<AgentType>>;
+  pluginsByAgent: Map<AgentType, Set<string>>;
+};
+
+function isPluginEntry(entry: fs.Dirent): boolean {
+  return entry.isDirectory() || entry.isSymbolicLink();
+}
+
+function buildInstallIndex(globalInstall: boolean, cwd: string): InstallIndex {
+  const agentsByPlugin = new Map<string, Set<AgentType>>();
+  const pluginsByAgent = new Map<AgentType, Set<string>>();
+  const allAgents = Object.keys(AGENTS) as AgentType[];
+
+  for (const agent of allAgents) {
+    const dir = getAgentPluginsDir(agent, globalInstall, cwd);
+    if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+      continue;
+    }
+
+    const names = new Set<string>();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!isPluginEntry(entry)) {
+        continue;
+      }
+      names.add(entry.name);
+      const owners = agentsByPlugin.get(entry.name) ?? new Set<AgentType>();
+      owners.add(agent);
+      agentsByPlugin.set(entry.name, owners);
+    }
+
+    if (names.size > 0) {
+      pluginsByAgent.set(agent, names);
+    }
+  }
+
+  return { agentsByPlugin, pluginsByAgent };
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
+}
+
+function orderAgentsForDisplay(agents: AgentType[]): AgentType[] {
+  return Array.from(new Set(agents)).sort((a, b) => {
+    if (a === "universal" && b !== "universal") {
+      return -1;
+    }
+    if (b === "universal" && a !== "universal") {
+      return 1;
+    }
+    return a.localeCompare(b);
+  });
+}
+
+function resolveCandidateAgentsForPlugins(
+  pluginNames: string[],
+  index: InstallIndex,
+): AgentType[] {
+  return orderAgentsForDisplay(
+    pluginNames.flatMap((name) =>
+      Array.from(index.agentsByPlugin.get(name) ?? []),
+    ),
+  );
+}
+
+async function executeRemove(
+  positional: string[],
+  options: RemoveOptions,
+): Promise<void> {
+  const interactive = canUseInteractive(options.nonInteractive);
+  await renderRemoveFlowHeader();
+  const cwd = process.cwd();
+  const globalInstall = Boolean(options.global);
+  let index: InstallIndex;
+
+  try {
+    index = buildInstallIndex(globalInstall, cwd);
+  } catch (error) {
+    await renderStaticScreen([
+      failedStepsSection(["failed to index installed plugins"]),
+    ]);
+    throw error;
+  }
+
+  if (index.agentsByPlugin.size === 0) {
+    throw new Error("No installed plugins found to remove.");
+  }
+
+  const allPluginCandidates = uniqueSorted(index.agentsByPlugin.keys());
+  if (allPluginCandidates.length === 0) {
+    throw new Error("No installed plugins found to remove.");
+  }
+
+  const scope = globalInstall ? "global" : "local";
+  const scopedAgentRows = resolveAddPluginAgentSelectionRows(scope);
+  const scopedAgentRowsById = new Map<AgentType, SelectionRow>(
+    scopedAgentRows.map((row) => [row.id as AgentType, row]),
+  );
+  const scopeAllowedAgents = new Set<AgentType>(
+    scopedAgentRows.map((row) => row.id as AgentType),
+  );
+
+  const explicitPlugins = [...(options.skill || []), ...positional];
+  let finalPlugins = uniqueSorted(explicitPlugins);
+  let requiresInteractivePluginSelection = false;
+  if (finalPlugins.length === 0) {
+    if (allPluginCandidates.length === 1) {
+      finalPlugins = [allPluginCandidates[0]];
+    } else if (interactive) {
+      requiresInteractivePluginSelection = true;
+    } else {
+      throw new Error(
+        "Multiple installed plugins found. Use --plugin <name>... or run in TTY without --non-interactive.",
+      );
+    }
+  }
+
+  let agents: AgentType[] = [];
+  let candidateAgents: AgentType[] = [];
+  try {
+    if (options.agent && options.agent.length > 0) {
+      if (options.agent.includes("*")) {
+        candidateAgents = orderAgentsForDisplay(
+          Array.from(index.pluginsByAgent.keys()),
+        );
+        agents = candidateAgents;
+      } else {
+        candidateAgents = resolveAgents(options.agent).filter((agent) =>
+          scopeAllowedAgents.has(agent),
+        );
+        agents = candidateAgents;
+      }
+    } else {
+      candidateAgents =
+        finalPlugins.length > 0
+          ? resolveCandidateAgentsForPlugins(finalPlugins, index)
+          : [];
+
+      if (candidateAgents.length === 0 && !requiresInteractivePluginSelection) {
+        throw new Error("No installed plugins found to remove.");
+      }
+      if (candidateAgents.length === 1) {
+        agents = candidateAgents;
+      } else if (candidateAgents.length > 1 && !interactive) {
+        throw new Error(
+          "Multiple agents found. Use --agent <name>... or run in TTY without --non-interactive.",
+        );
+      }
+    }
+
+    candidateAgents = candidateAgents.filter((agent) =>
+      scopeAllowedAgents.has(agent),
+    );
+    agents = agents.filter((agent) => scopeAllowedAgents.has(agent));
+    candidateAgents = orderAgentsForDisplay(candidateAgents);
+    agents = orderAgentsForDisplay(agents);
+  } catch (error) {
+    await renderStaticScreen([
+      failedStepsSection(["failed to resolve target candidates"]),
+    ]);
+    throw error;
+  }
+
+  await renderStaticScreen([
+    completedStepsSection([
+      "installed plugins indexed",
+      "target candidates resolved",
+      "interactive session ready",
+    ]),
+    sourceSection(shortenHomePath(cwd)),
+  ]);
+
+  let renderedPluginsPanel = false;
+  finalPlugins = await runManySelectionStep({
+    interactive,
+    rows: buildRemovePluginSelectionRows(allPluginCandidates),
+    selectedIds: finalPlugins,
+    shouldPrompt: requiresInteractivePluginSelection,
+    prompt: {
+      title: "Choose Plugins",
+      required: true,
+      requiredMessage: "At least one plugin must be selected",
+      searchable: true,
+      keyHints: REMOVE_PLUGINS_KEY_HINTS,
+      view: REMOVE_PLUGINS_SELECTION_VIEW,
+    },
+    renderClosed: (selectedIds) =>
+      renderRemovePluginsPanel({
+        plugins: allPluginCandidates,
+        selectedNames: selectedIds,
+      }),
+  });
+  renderedPluginsPanel = true;
+
+  if (!options.agent || options.agent.length === 0) {
+    candidateAgents = resolveCandidateAgentsForPlugins(finalPlugins, index);
+    candidateAgents = candidateAgents.filter((agent) =>
+      scopeAllowedAgents.has(agent),
+    );
+    candidateAgents = orderAgentsForDisplay(candidateAgents);
+
+    if (candidateAgents.length === 0) {
+      throw new Error("No installed plugins found to remove.");
+    }
+
+    if (agents.length === 0 && candidateAgents.length === 1) {
+      agents = candidateAgents;
+    }
+  }
+
+  const shouldPromptAgents =
+    interactive && (!options.agent || options.agent.length === 0);
+  const visibleCandidateAgents = candidateAgents.filter((agent) =>
+    scopeAllowedAgents.has(agent),
+  );
+  const selectedAgentIds = await runManySelectionStep({
+    interactive,
+    rows: buildRemoveAgentSelectionRows(
+      visibleCandidateAgents,
+      scopedAgentRowsById,
+    ),
+    selectedIds: agents,
+    shouldPrompt: shouldPromptAgents,
+    prompt: {
+      title: "Choose Agents",
+      required: true,
+      requiredMessage: "At least one agent must be selected",
+      searchable: true,
+      keyHints: REMOVE_AGENTS_KEY_HINTS,
+      view: REMOVE_AGENTS_SELECTION_VIEW,
+    },
+    renderClosed: (selectedIds) =>
+      renderRemoveAgentsPanel({
+        agents: visibleCandidateAgents,
+        selectedAgents: selectedIds as AgentType[],
+        scopedAgentRowsById,
+      }),
+  });
+  const selectedAgentSet = new Set(selectedAgentIds);
+  agents = visibleCandidateAgents.filter((agent) =>
+    selectedAgentSet.has(agent),
+  );
+
+  if (!renderedPluginsPanel) {
+    finalPlugins = await runManySelectionStep({
+      interactive,
+      rows: buildRemovePluginSelectionRows(allPluginCandidates),
+      selectedIds: finalPlugins,
+      shouldPrompt: false,
+      prompt: {
+        title: "Choose Plugins",
+        required: true,
+        requiredMessage: "At least one plugin must be selected",
+        searchable: true,
+        keyHints: REMOVE_PLUGINS_KEY_HINTS,
+        view: REMOVE_PLUGINS_SELECTION_VIEW,
+      },
+      renderClosed: (selectedIds) =>
+        renderRemovePluginsPanel({
+          plugins: allPluginCandidates,
+          selectedNames: selectedIds,
+        }),
+    });
+  }
+
+  if (finalPlugins.length === 0) {
+    throw new Error("No installed plugins found to remove.");
+  }
+
+  const targetPluginNames = new Set<string>();
+  const requestedPlugins = new Set(finalPlugins);
+  for (const agent of agents) {
+    for (const name of index.pluginsByAgent.get(agent) ?? []) {
+      if (requestedPlugins.has(name)) {
+        targetPluginNames.add(name);
+      }
+    }
+  }
+  if (targetPluginNames.size === 0) {
+    throw new Error("No installed plugins found to remove.");
+  }
+
+  const targetPluginList = uniqueSorted(targetPluginNames);
+
+  const confirmSelection = await runOneSelectionStep({
+    interactive,
+    rows: buildRemoveConfirmSelectionRows(),
+    selectedId: "yes",
+    shouldPrompt: interactive,
+    prompt: {
+      title: "Confirm Uninstall",
+      required: true,
+      requiredMessage: "Select Yes or No",
+      searchable: false,
+      keyHints: REMOVE_CONFIRM_KEY_HINTS,
+      view: {
+        ...REMOVE_CONFIRM_SELECTION_VIEW,
+        instructionLine: `Are you sure you want to uninstall ${targetPluginList.length} plugin(s)?`,
+      },
+      initialSelectedId: "yes",
+    },
+    renderClosed: (selectedId) =>
+      renderRemoveConfirmPanel({
+        selectedId,
+      }),
+  });
+  const confirmed = confirmSelection === "yes";
+
+  if (!confirmed) {
+    await renderStaticScreen([linesSection(["Uninstall cancelled."])]);
+    return;
+  }
+
+  await renderStaticScreen([
+    renderRemoveUninstallSummaryBox({
+      globalInstall,
+      pluginNames: targetPluginList,
+      agentDisplayNames: agents.map((agent) => AGENTS[agent].displayName),
+    }),
+  ]);
+
+  let removedCount = 0;
+  const completedRemovalSteps: string[] = [];
+  let failedLabel = "failed to remove selected plugins";
+
+  try {
+    for (const agent of agents) {
+      const dir = getAgentPluginsDir(agent, globalInstall, cwd);
+      if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+        continue;
+      }
+
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+          continue;
+        }
+
+        if (!targetPluginNames.has(entry.name)) {
+          continue;
+        }
+
+        const fullPath = path.join(dir, entry.name);
+        failedLabel = `failed to remove ${entry.name} from ${agent}`;
+        fs.rmSync(fullPath, { recursive: true, force: true });
+        removedCount += 1;
+        completedRemovalSteps.push(`removed ${entry.name} from ${agent}`);
+      }
+    }
+  } catch (error) {
+    await renderStaticScreen([failedStepsSection([failedLabel])]);
+    throw error;
+  }
+
+  const completionSections = [];
+  if (completedRemovalSteps.length > 0) {
+    completionSections.push(completedStepsSection(completedRemovalSteps));
+  }
+  completionSections.push(removeCompletionSummarySection(removedCount));
+  await renderStaticScreen(completionSections);
+}
+
+function configureRemoveCommand(
+  command: Command,
+  action: (plugins: string[], options: RemoveCommanderOptions) => Promise<void>,
+): Command {
+  return command
+    .description("Remove installed plugins")
+    .argument("[plugins...]", "Plugin names")
+    .option("-a, --agent <agents...>", "Target agent(s)")
+    .option("-p, --plugin <plugins...>", "Explicit plugin names")
+    .option("-g, --global", "Remove global installs")
+    .option("--non-interactive", "Disable prompts")
+    .action(action);
+}
 
 export function registerRemoveCommand(
   program: Command,
-  context: CliCommandContext,
+  ctx: CliCommandContext,
 ): void {
-  program
-    .command("remove")
-    .description("Remove an AI agent plugin")
-    .argument("<plugin>", "Plugin name to remove")
-    .action(
-      context.wrapAction("remove", async (_plugin: string) => {
-        // TODO: implement remove plugin logic
-      }),
-    );
+  configureRemoveCommand(
+    program.command("remove").alias("rm"),
+    ctx.wrapAction(
+      "remove",
+      async (plugins: string[], options: RemoveCommanderOptions) => {
+        await executeRemove(plugins, toRemoveOptions(options));
+      },
+    ),
+  );
+}
+
+export async function runRemove(args: string[]): Promise<void> {
+  const command = configureRemoveCommand(
+    new Command().name("remove"),
+    async (plugins, options) => {
+      await executeRemove(plugins, toRemoveOptions(options));
+    },
+  );
+  await parseStandaloneCommand(command, args);
 }

--- a/apps/pluginspp-cli/src/ui/screens.tsx
+++ b/apps/pluginspp-cli/src/ui/screens.tsx
@@ -891,16 +891,18 @@ export function installationSummarySection(options: {
 
 export function uninstallSummarySection(options: {
   globalInstall: boolean;
-  skillNames: string[];
+  itemNames: string[];
+  itemLabel?: string;
   agentDisplayNames: string[];
 }): UiSection {
+  const itemLabel = options.itemLabel || "Skills";
   return panelSection({
     title: "Uninstall Summary",
     lines: [
       `Scope: ${options.globalInstall ? "global" : "current project"}`,
       "",
-      `Skills (${options.skillNames.length}):`,
-      ...options.skillNames.map((name) => `  - ${name}`),
+      `${itemLabel} (${options.itemNames.length}):`,
+      ...options.itemNames.map((name) => `  - ${name}`),
       "",
       `Agents (${options.agentDisplayNames.length}): ${compactAgentDisplayNames(
         [...options.agentDisplayNames].sort((a, b) => a.localeCompare(b)),

--- a/apps/pluginspp-cli/tests/e2e/plugins-cli.e2e.test.ts
+++ b/apps/pluginspp-cli/tests/e2e/plugins-cli.e2e.test.ts
@@ -222,6 +222,203 @@ describe("pluginspp binary @e2e", () => {
     }
   }, 30_000);
 
+  it("removes an explicit plugin from an explicit agent without touching skills @e2e", async () => {
+    const workdir = fs.mkdtempSync(
+      path.join(process.cwd(), "tmp-plugins-cli-remove-explicit-"),
+    );
+    try {
+      const { repoRoot } = createPluginSourceRepo(workdir, [
+        { folderName: "plugin-alpha", description: "alpha plugin" },
+      ]);
+
+      const addResult = await runCli(workdir, [
+        "add",
+        repoRoot,
+        "--agent",
+        "codex",
+        "claude-code",
+        "--plugin",
+        "plugin-alpha",
+        "--non-interactive",
+      ]);
+
+      expect(addResult.code).toBe(0);
+
+      fs.mkdirSync(path.join(workdir, ".agents", "skills", "plugin-alpha"), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(workdir, ".agents", "skills", "plugin-alpha", "SKILL.md"),
+        "# sentinel\n",
+        "utf8",
+      );
+      fs.mkdirSync(path.join(workdir, ".claude", "skills", "plugin-alpha"), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(workdir, ".claude", "skills", "plugin-alpha", "SKILL.md"),
+        "# sentinel\n",
+        "utf8",
+      );
+
+      const removeResult = await runCli(workdir, [
+        "remove",
+        "--plugin",
+        "plugin-alpha",
+        "--agent",
+        "codex",
+        "--non-interactive",
+      ]);
+
+      expect(removeResult.code).toBe(0);
+      expect(removeResult.output).toContain("Plugins (1):");
+      expect(removeResult.output).toContain("Total removed: 1");
+      expect(
+        fs.existsSync(
+          path.join(workdir, ".agents", "plugins", "cache", "plugin-alpha"),
+        ),
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(workdir, ".claude", "plugins", "cache", "plugin-alpha"),
+        ),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(workdir, ".agents", "skills", "plugin-alpha")),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(workdir, ".claude", "skills", "plugin-alpha")),
+      ).toBe(true);
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("removes the only installed plugin for an explicit agent in non-interactive mode @e2e", async () => {
+    const workdir = fs.mkdtempSync(
+      path.join(process.cwd(), "tmp-plugins-cli-remove-single-"),
+    );
+    try {
+      const { repoRoot } = createPluginSourceRepo(workdir, [
+        { folderName: "plugin-alpha", description: "alpha plugin" },
+      ]);
+
+      const addResult = await runCli(workdir, [
+        "add",
+        repoRoot,
+        "--agent",
+        "codex",
+        "--plugin",
+        "plugin-alpha",
+        "--non-interactive",
+      ]);
+
+      expect(addResult.code).toBe(0);
+
+      const removeResult = await runCli(workdir, [
+        "remove",
+        "--agent",
+        "codex",
+        "--non-interactive",
+      ]);
+
+      expect(removeResult.code).toBe(0);
+      expect(removeResult.output).toContain("Total removed: 1");
+      expect(
+        fs.existsSync(
+          path.join(workdir, ".agents", "plugins", "cache", "plugin-alpha"),
+        ),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("fails in non-interactive mode when installed plugin selection is ambiguous @e2e", async () => {
+    const workdir = fs.mkdtempSync(
+      path.join(process.cwd(), "tmp-plugins-cli-remove-ambiguous-plugin-"),
+    );
+    try {
+      const { repoRoot } = createPluginSourceRepo(workdir, [
+        { folderName: "plugin-alpha", description: "alpha plugin" },
+        { folderName: "plugin-beta", description: "beta plugin" },
+      ]);
+
+      const addAlpha = await runCli(workdir, [
+        "add",
+        repoRoot,
+        "--agent",
+        "codex",
+        "--plugin",
+        "plugin-alpha",
+        "--non-interactive",
+      ]);
+      expect(addAlpha.code).toBe(0);
+
+      const addBeta = await runCli(workdir, [
+        "add",
+        repoRoot,
+        "--agent",
+        "codex",
+        "--plugin",
+        "plugin-beta",
+        "--non-interactive",
+      ]);
+      expect(addBeta.code).toBe(0);
+
+      const removeResult = await runCli(workdir, [
+        "remove",
+        "--agent",
+        "codex",
+        "--non-interactive",
+      ]);
+
+      expect(removeResult.code).toBe(1);
+      expect(removeResult.output).toContain(
+        "Multiple installed plugins found. Use --plugin <name>... or run in TTY without --non-interactive.",
+      );
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("fails in non-interactive mode when one plugin is installed across multiple agents @e2e", async () => {
+    const workdir = fs.mkdtempSync(
+      path.join(process.cwd(), "tmp-plugins-cli-remove-ambiguous-agent-"),
+    );
+    try {
+      const { repoRoot } = createPluginSourceRepo(workdir, [
+        { folderName: "plugin-alpha", description: "alpha plugin" },
+      ]);
+
+      const addResult = await runCli(workdir, [
+        "add",
+        repoRoot,
+        "--agent",
+        "codex",
+        "claude-code",
+        "--plugin",
+        "plugin-alpha",
+        "--non-interactive",
+      ]);
+
+      expect(addResult.code).toBe(0);
+
+      const removeResult = await runCli(workdir, [
+        "remove",
+        "plugin-alpha",
+        "--non-interactive",
+      ]);
+
+      expect(removeResult.code).toBe(1);
+      expect(removeResult.output).toContain(
+        "Multiple agents found. Use --agent <name>... or run in TTY without --non-interactive.",
+      );
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   it("uses detected agents for wildcard installs in global mode @e2e", async () => {
     const workdir = fs.mkdtempSync(
       path.join(process.cwd(), "tmp-plugins-cli-global-"),
@@ -268,6 +465,87 @@ describe("pluginspp binary @e2e", () => {
           path.join(homeDir, ".cursor", "plugins", "cache", "plugin-alpha"),
         ),
       ).toBe(false);
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("removes only global plugin installs when --global is set @e2e", async () => {
+    const workdir = fs.mkdtempSync(
+      path.join(process.cwd(), "tmp-plugins-cli-remove-global-"),
+    );
+    try {
+      const homeDir = path.join(workdir, "home");
+      fs.mkdirSync(path.join(homeDir, ".codex"), { recursive: true });
+
+      const { repoRoot } = createPluginSourceRepo(workdir, [
+        { folderName: "plugin-alpha", description: "alpha plugin" },
+      ]);
+
+      const addResult = await runCli(
+        workdir,
+        [
+          "add",
+          repoRoot,
+          "--agent",
+          "codex",
+          "--plugin",
+          "plugin-alpha",
+          "--global",
+          "--non-interactive",
+        ],
+        {
+          HOME: homeDir,
+        },
+      );
+
+      expect(addResult.code).toBe(0);
+
+      fs.mkdirSync(
+        path.join(workdir, ".agents", "plugins", "cache", "plugin-alpha"),
+        { recursive: true },
+      );
+      fs.writeFileSync(
+        path.join(
+          workdir,
+          ".agents",
+          "plugins",
+          "cache",
+          "plugin-alpha",
+          "sentinel.txt",
+        ),
+        "keep local\n",
+        "utf8",
+      );
+
+      const removeResult = await runCli(
+        workdir,
+        [
+          "remove",
+          "--plugin",
+          "plugin-alpha",
+          "--agent",
+          "codex",
+          "--global",
+          "--non-interactive",
+        ],
+        {
+          HOME: homeDir,
+        },
+      );
+
+      expect(removeResult.code).toBe(0);
+      expect(removeResult.output).toContain("Total removed: 1");
+      expect(
+        fs.existsSync(
+          path.join(homeDir, ".codex", "plugins", "cache", "plugin-alpha"),
+        ),
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(workdir, ".agents", "plugins", "cache", "plugin-alpha"),
+        ),
+      ).toBe(true);
     } finally {
       fs.rmSync(workdir, { recursive: true, force: true });
     }

--- a/apps/pluginspp-cli/tests/unit/remove.unit.test.ts
+++ b/apps/pluginspp-cli/tests/unit/remove.unit.test.ts
@@ -1,0 +1,31 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { createTelemetryEmitter } from "@skillspp/core/telemetry";
+import { createCliCommandContext } from "../../src/command-builder";
+import { registerRemoveCommand } from "../../src/commands/remove";
+
+function buildRemoveCommand(): Command {
+  const program = new Command().name("pluginspp").exitOverride();
+  const context = createCliCommandContext(createTelemetryEmitter());
+  registerRemoveCommand(program, context);
+  return program.commands.find((command) => command.name() === "remove") as Command;
+}
+
+describe("pluginspp remove command @unit", () => {
+  it("matches the plugin-specific option surface @unit", () => {
+    const removeCommand = buildRemoveCommand();
+    const help = removeCommand.helpInformation();
+
+    expect(help).toContain("[plugins...]");
+    expect(help).toContain("--plugin");
+    expect(help).toContain("--agent");
+    expect(help).toContain("--non-interactive");
+    expect(help).not.toContain("--skill");
+    expect(help).not.toMatch(/(^|\s)--all(?:\s|,|$)/m);
+  });
+
+  it("registers the rm alias @unit", () => {
+    const removeCommand = buildRemoveCommand();
+    expect(removeCommand.aliases()).toContain("rm");
+  });
+});

--- a/packages/core/src/runtime/background-tasks.ts
+++ b/packages/core/src/runtime/background-tasks.ts
@@ -6,6 +6,7 @@ import {
   detectInstalledAgents,
   filterInstalledAgents,
   getAgentSkillsDir,
+  getAgentPluginsDir,
   resolveAgents,
 } from "./agents";
 import {

--- a/packages/core/src/runtime/background-tasks.ts
+++ b/packages/core/src/runtime/background-tasks.ts
@@ -6,7 +6,6 @@ import {
   detectInstalledAgents,
   filterInstalledAgents,
   getAgentSkillsDir,
-  getAgentPluginsDir,
   resolveAgents,
 } from "./agents";
 import {

--- a/packages/core/src/runtime/installer.ts
+++ b/packages/core/src/runtime/installer.ts
@@ -170,20 +170,26 @@ export function installSkill(
     options.globalInstall,
     options.cwd,
   );
-  const canonicalDir = installToCanonicalDir(skill.path, skillName, canonicalBase);
+  const canonicalDir = installToCanonicalDir(
+    skill.path,
+    skillName,
+    canonicalBase,
+  );
 
   const installedTo = [
     { agent: canonicalAgent, path: canonicalDir, mode: options.mode },
-    ...uniqueAgents.slice(1).map((agent) =>
-      installSkillToAgent(
-        skillName,
-        canonicalDir,
-        agent,
-        options.mode,
-        options.globalInstall,
-        options.cwd,
+    ...uniqueAgents
+      .slice(1)
+      .map((agent) =>
+        installSkillToAgent(
+          skillName,
+          canonicalDir,
+          agent,
+          options.mode,
+          options.globalInstall,
+          options.cwd,
+        ),
       ),
-    ),
   ];
 
   return {
@@ -218,16 +224,18 @@ export function installPlugin(
 
   const installedTo = [
     { agent: canonicalAgent, path: canonicalDir, mode: options.mode },
-    ...uniqueAgents.slice(1).map((agent) =>
-      installPluginToAgent(
-        pluginName,
-        canonicalDir,
-        agent,
-        options.mode,
-        options.globalInstall,
-        options.cwd,
+    ...uniqueAgents
+      .slice(1)
+      .map((agent) =>
+        installPluginToAgent(
+          pluginName,
+          canonicalDir,
+          agent,
+          options.mode,
+          options.globalInstall,
+          options.cwd,
+        ),
       ),
-    ),
   ];
 
   return {


### PR DESCRIPTION
## Summary

- implement `pluginspp remove|rm` as the plugin-specific mirror of `skillspp remove`
- resolve installed plugins from agent plugin cache directories and remove only plugin installs, leaving skill directories untouched
- add unit and e2e coverage for the command surface, ambiguity handling, and global removal paths
- Breaking changes: none
- Closes #10

## Issue Checklist

- [x] Mirror `skillspp remove` command behavior in `pluginspp remove`
- [x] Keep the interactive prompt and TUI flow aligned with the mirrored command logic
- [x] Follow the same required-argument decision flow as the source command
- [x] Support `pluginspp remove|rm [options] [plugins...]`
- [x] Support `-a, --agent <agents...>`
- [x] Support explicit plugin selection via `--plugin <plugins...>` in the implemented CLI flow
- [x] Support `-g, --global`
- [x] Support `--non-interactive`
- [x] Cover single-plugin removal from an explicit agent
- [x] Cover removal with only `-a <agent>` when one installed plugin is unambiguous
- [x] Cover non-interactive ambiguity for multiple installed plugins
- [x] Cover non-interactive ambiguity for one plugin installed across multiple agents
- [x] Cover global removal paths

Note: the issue body contains outdated examples such as `--all`. This PR follows the implemented remove command contract in the branch.

## Validation

- [x] `corepack pnpm run typecheck`
- [x] `corepack pnpm run lint`
- [x] `corepack pnpm run test:unit`
- [x] `corepack pnpm run build`

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added or updated when behavior changed
- [ ] Documentation updated when needed
- [x] Breaking changes are explicitly called out
