### PR TITLE
fix(test-kit): update appRoot resolution in MCP contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         run: |
           if [ "${BASE_REF}" = "development" ]; then
             case "${HEAD_REF}" in
-              feature/*|fix/*|chore/*)
+              feature/*|feat/*|bugfix/*|fix/*|hotfix/*|chore/*)
                 ;;
               *)
-                echo "PRs to development must come from feature/*, fix/*, or chore/* branches."
+                echo "PRs to development must come from feature/*, feat/*, bugfix/*, fix/*, hotfix/*, or chore/* branches."
                 echo "Current head branch: ${HEAD_REF}"
                 exit 1
                 ;;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,11 @@ ci(release): publish CLI through semantic-release automation
 
 Use this branch strategy:
 
-- Open feature branches as `feature/*`, `fix/*`, or `chore/*`.
+- Open working branches using one of these prefixes:
+  - `feature/*` or `feat/*` for new features (for example, `feature/add-login-page`, `feat/add-login-page`).
+  - `bugfix/*` or `fix/*` for bug fixes (for example, `bugfix/fix-header-bug`, `fix/header-bug`).
+  - `hotfix/*` for urgent fixes (for example, `hotfix/security-patch`).
+  - `chore/*` for maintenance/non-feature work (for example, dependency or docs updates).
 - Target `development` for regular work.
 - Promote to `main` through a dedicated PR from `development`.
 

--- a/apps/skillspp-cli/package.json
+++ b/apps/skillspp-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skillspp",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Skills++ CLI for skill source validation and management workflows.",
   "license": "MIT",
   "type": "module",

--- a/apps/skillspp-cli/tests/unit/background-runner.unit.test.ts
+++ b/apps/skillspp-cli/tests/unit/background-runner.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+const runBackgroundTaskInPlatform = vi.fn(async () => ({ durationMs: 123 }));
+
+vi.mock("@skillspp/platform-node", () => ({
+  runBackgroundTask: runBackgroundTaskInPlatform,
+}));
+
+const { runBackgroundTask } = await import("../../src/runtime/background-runner");
+
+describe("CLI background runner adapter @unit", () => {
+  it("uses the colocated background executor module @unit", async () => {
+    const response = await runBackgroundTask(
+      {
+        kind: "test.blocking",
+        payload: {
+          durationMs: 123,
+        },
+      },
+      {
+        onProgress: () => {
+          // no-op
+        },
+      }
+    );
+
+    expect(runBackgroundTaskInPlatform).toHaveBeenCalled();
+    const secondArg = (runBackgroundTaskInPlatform.mock.calls[0] as any)?.[1];
+    expect(typeof secondArg?.executorModule).toBe("string");
+    expect(secondArg.executorModule).toContain("background-executor");
+    expect(response).toEqual({ durationMs: 123 });
+  });
+});

--- a/apps/skillspp-mcp/tests/contract/validate-tool.contract.test.ts
+++ b/apps/skillspp-mcp/tests/contract/validate-tool.contract.test.ts
@@ -2,15 +2,18 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 async function callMcpTool(input: object): Promise<any> {
-  const appRoot = process.cwd();
-  const workspaceRoot = path.resolve(appRoot, "../..");
+  const appRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../.."
+  );
   const child = spawn(
     process.execPath,
     [
-      path.resolve(workspaceRoot, "node_modules/tsx/dist/cli.mjs"),
+      path.resolve(appRoot, "node_modules/tsx/dist/cli.mjs"),
       path.resolve(appRoot, "src/index.ts"),
     ],
     {


### PR DESCRIPTION
## Summary

This PR stabilizes MCP contract test execution by fixing how the app root is resolved and adds coverage for the CLI background runner adapter.

- Resolve `appRoot` from the test file location (`import.meta.url` + `fileURLToPath`) instead of relying on `process.cwd()`.
- Use the resolved `appRoot` for `tsx` CLI path resolution in MCP contract test execution.
- Add a unit test that verifies the CLI background runner delegates to `@skillspp/platform-node` and passes a colocated `background-executor` module path.
- Bump package version from `0.2.0` to `0.3.0`.

Why: MCP contract tests were sensitive to the shell working directory; deriving paths from module location makes test execution deterministic across environments (local, CI, and different runners).

## Validation

- [ ] `corepack pnpm run typecheck`
- [ ] `corepack pnpm run lint`
- [ ] `corepack pnpm run test:unit`
- [ ] `corepack pnpm run build`

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added or updated when behavior changed
- [ ] Documentation updated when needed
- [x] Breaking changes are explicitly called out

### Breaking Changes

None.
